### PR TITLE
Fix small rendering issue @ exactly 1200px width

### DIFF
--- a/assets/scss/components/_navigation.scss
+++ b/assets/scss/components/_navigation.scss
@@ -45,7 +45,7 @@ nav {
   }
 }
 
-@media only screen and (min-width: 500px) and (max-width: 1200px) {
+@media only screen and (min-width: 500px) and (max-width: 1199px) {
   nav {
     align-content: center;
 


### PR DESCRIPTION
There are a couple overlapping media queries in this scss that result in a UX issue when the browser window is exactly 1200px wide, this small change corrects the issue by removing the overlap between the two CSS rules.