### PR TITLE
Fix menu flickering when resizing browser

### DIFF
--- a/assets/scss/components/_navigation.scss
+++ b/assets/scss/components/_navigation.scss
@@ -20,7 +20,6 @@ nav {
 
   visibility: hidden;
   opacity: 0;
-  transition: all 0.4s cubic-bezier(1, 0, 0, 1);
 
   form,
   .button-email {
@@ -42,6 +41,12 @@ nav {
 
   & li {
     margin-bottom: 0;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  nav {
+    transition: all 0.4s cubic-bezier(1, 0, 0, 1);
   }
 }
 


### PR DESCRIPTION
When transitioning over the media query width boundary, the display attribute for the container nav is flipped to flex, which triggers a CSS transition, temporarily making the container visible. 

This change moves the CSS transition to another media query that only triggers on smaller screen sizes (and would happen at a different time than other media query boundary transitions). Tested in Chrome and Firefox.

Before: 
https://www.loom.com/share/c5de704eb98b48b3a6faacc4064bd9cb

After:
https://www.loom.com/share/52ed3f541a2d448caf8a0083cd550372

